### PR TITLE
pass dim_ordering to imreader

### DIFF
--- a/keras/preprocessing/image.py
+++ b/keras/preprocessing/image.py
@@ -742,6 +742,7 @@ class DirectoryIterator(Iterator):
             self.reader_config['target_size'] = target_size
 
         self.dim_ordering = dim_ordering
+        self.reader_config['dim_ordering'] = dim_ordering
         if class_mode not in {'categorical', 'binary', 'sparse', None}:
             raise ValueError('Invalid class_mode:', class_mode,
                              '; expected one of "categorical", '


### PR DESCRIPTION
When using a generator the dim_ordering option wasn't passed to the image reader. This is because it wasn't in self.reader_config, but this fixes it.
